### PR TITLE
Integrate yoavram/curriculum-vitae as submodule for CV page

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "content/cv"]
+	path = content/cv
+	url = git@github.com:yoavram/curriculum-vitae.git

--- a/models/cv.ini
+++ b/models/cv.ini
@@ -1,0 +1,3 @@
+[model]
+name = CV
+inherits = page

--- a/templates/cv.html
+++ b/templates/cv.html
@@ -1,0 +1,18 @@
+{% extends "page.html" %}
+{% block subtitle %}
+
+{% set pdf = this.attachments.filter(F._path.endswith('curriculum-vitae.pdf')).first() %}
+{% set word = this.attachments.filter(F._path.endswith('curriculum-vitae.docx')).first() %}
+{% set markdown = this.attachments.filter(F._path.endswith('curriculum-vitae.md')).first() %}
+
+{% if pdf %}
+	<a href="{{ pdf._path }}"><i class="fa fa-file-pdf-o fw"></i> pdf</a>
+{% endif %}
+{% if word %}
+	<a href="{{ word._path }}"><i class="fa fa-file-word-o fw"></i> word</a>
+{% endif %}
+{% if markdown %}
+	<a href="{{ markdown._path }}"><i class="fa fa-file-code-o fw"></i> markdown</a>
+{% endif %}
+
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -47,7 +47,7 @@
             %}><a href="{{ '/'|url }}"><i class="fa fa-home fa-fw" aria-hidden="true"></i> Home</a></li>
             {% for icon, href, title in [
             ['fa fa-flask', '/research', 'Research'],
-            ['fa fa-university', 'https://github.com/yoavram/curriculum-vitae/blob/master/curriculum-vitae.pdf?raw=true', 'CV'],
+            ['fa fa-university', '/cv', 'CV'],
             ['fa fa-newspaper-o', '/publications', 'Publications'],
             ['fa fa-microphone', '/talks', 'Talks'],
             ['fa fa-rss', '/blog', 'Blog'],

--- a/templates/page.html
+++ b/templates/page.html
@@ -9,7 +9,7 @@
   		class="col-sm-12"
   	{% endif %}
   	>  	  
-    <h2>{{ this.title }}</h2>
+    <h1>{{ this.title }}</h1>
   		{{ this.body }}
   	</div>
   	<div class="col-sm-4 col-sm-offset-1 hidden-xs">

--- a/templates/page.html
+++ b/templates/page.html
@@ -10,6 +10,7 @@
   	{% endif %}
   	>  	  
     <h1>{{ this.title }}</h1>
+    {% block subtitle %}{% endblock %}
   		{{ this.body }}
   	</div>
   	<div class="col-sm-4 col-sm-offset-1 hidden-xs">


### PR DESCRIPTION
[yoavram/curriculum-vitae](https://github.com/yoavram/curriculum-vitae/commit/1c6f08d31536b56e0aa7ad56cd3bf4c37a5ca168) was changed to support this website. Knitting the CV on that repo creates a `contents.lr` file suitable for lektor to digest. 
The CV repo is a submodule of this repo in a `cv` folder inside `content`, so that the generated `contents.lr` will be used by lektor to generate `/cv/index.html`.
In addition, `curriculum-vitae.*` are attached to the page, appearing as links in the subtitle - this was facilitated by creating a new CV model and template; the new template extends `page.html` by setting a subtitle block (which was added to `page.html`).

Closes #5.
